### PR TITLE
TO_READ renamed to TOREAD

### DIFF
--- a/user-service/src/main/java/xyz/bookself/users/domain/BookListEnum.java
+++ b/user-service/src/main/java/xyz/bookself/users/domain/BookListEnum.java
@@ -1,5 +1,5 @@
 package xyz.bookself.users.domain;
 
 public enum BookListEnum {
-    READ, READING, DNF, TO_READ;
+    READ, READING, DNF, TOREAD;
 }


### PR DESCRIPTION
- the mismatch with its value in the PostgreSQL is failing requests.
- Easier to rename it here than to alter the Postgres table